### PR TITLE
IE8 support: use attachEvent to attach click handler

### DIFF
--- a/lib/perfbar.js
+++ b/lib/perfbar.js
@@ -458,9 +458,15 @@ window.perfBar = window.perfBar || {};
 
   // private method that handles clicks on #perfBar (show/hide) stuff.
   function _handleClick() {
-    perfBar.el.querySelector('.perfBar-bar').addEventListener('click', function(e) {
+    var elem = perfBar.el.querySelector('.perfBar-bar');
+    var handler = function(e) {
       perfBar.el.classList.toggle('perfBar-is-active')
-    })
+    };
+    if (elem.addEventListener) {
+      elem.addEventListener('click', handler);
+    } else if (elem.attachEvent) {
+      elem.attachEvent('onclick', handler);
+    }
   }
 
 })()


### PR DESCRIPTION
This is all it took to make perfBar work in IE8.
