### PR TITLE
Add testsComplete callback to config

### DIFF
--- a/build/perfbar.js
+++ b/build/perfbar.js
@@ -1,4 +1,4 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 module.exports = function () {
 
   if (typeof window.Element === "undefined" || "classList" in document.documentElement) return;
@@ -121,6 +121,10 @@ window.perfBar = window.perfBar || {};
       }
 
       perfBar.runPerfMetrics('others')
+
+      if (perfBar.config.testsComplete) {
+        perfBar.config.testsComplete(perfBar.metrics)
+      }
     }, 1000)
   }
 
@@ -541,8 +545,8 @@ window.perfBar = window.perfBar || {};
 })()
 },{"./classList.js":1,"./templates/bar.hbs":3,"./templates/stat.hbs":4}],3:[function(require,module,exports){
 // hbsfy compiled Handlebars template
-var Handlebars = require('hbsfy/runtime');
-module.exports = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+var HandlebarsCompiler = require('hbsfy/runtime');
+module.exports = HandlebarsCompiler.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
   
@@ -553,8 +557,8 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
 
 },{"hbsfy/runtime":12}],4:[function(require,module,exports){
 // hbsfy compiled Handlebars template
-var Handlebars = require('hbsfy/runtime');
-module.exports = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+var HandlebarsCompiler = require('hbsfy/runtime');
+module.exports = HandlebarsCompiler.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
   var buffer = "", stack1, helper, functionType="function", escapeExpression=this.escapeExpression, self=this;
@@ -1104,4 +1108,4 @@ module.exports = require('./dist/cjs/handlebars.runtime');
 },{"./dist/cjs/handlebars.runtime":5}],12:[function(require,module,exports){
 module.exports = require("handlebars/runtime")["default"];
 
-},{"handlebars/runtime":11}]},{},[2])
+},{"handlebars/runtime":11}]},{},[2]);

--- a/lib/perfbar.js
+++ b/lib/perfbar.js
@@ -46,6 +46,10 @@ window.perfBar = window.perfBar || {};
       }
 
       perfBar.runPerfMetrics('others')
+
+      if (perfBar.config.testsComplete) {
+        perfBar.config.testsComplete(perfBar.metrics)
+      }
     }, 1000)
   }
 


### PR DESCRIPTION
Adds a callback after metrics have run to be called if present in the config object passed on initialization.

Found myself wanting more of an "alert" when a perf test would fail.

Would allow developers some flexibility in how to address/handle issues. For example:

``` javascript
perfBar.init({
  budget: {
    globalJS: {
      max: 1
    },
    numOfEl: {
      max: 50
    }
  },
  testsComplete: function (results) {
    var color = '#FF3535';

    console.group('perfBar Tests');
    for(var prop in results) {
      if (results[prop].isBad) {
        console.log ('%c %c  ' + prop + ' %c %c ' + results[prop].hint + ' ', "color: "+color+";background:"+color, "color:"+color+";background:#333333", "background:#333333", "color:#777777;background:#e5e5e5");
        perfBar.el.classList.toggle('perfBar-is-active');
      }
    }
    console.groupEnd();
  }
});
```

Would produce the following and open the perfBar metrics container:

![alt text](http://f.cl.ly/items/0c2c0e361A423z3q0633/Screen%20Shot%202014-08-26%20at%2011.26.49%20PM.png)

Thoughts?
